### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,7 +28,7 @@ jobs:
           github.com/go-vela/vela-artifactory/cmd/vela-artifactory
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: target/vela-artifactory
         cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           github.com/go-vela/vela-artifactory/cmd/vela-artifactory
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: target/vela-artifactory
         cache: true


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore